### PR TITLE
Update avr core wrap to 1.8.2

### DIFF
--- a/subprojects/arduinocore-avr.wrap
+++ b/subprojects/arduinocore-avr.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
 directory = avr
-
-source_url = http://downloads.arduino.cc/cores/avr-1.6.20.tar.bz2
-source_filename = avr-1.6.20.tar.bz2
-source_hash = 61f3d59a2ab2e9191230e91e79ee91c05f32b32c33129d34d76ef87e56d257e1
-
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/arduinocore-avr/1.6.20/1/get_zip
-patch_filename = arduinocore-avr-1.6.20-1-wrap.zip
-patch_hash = 08b6521ce0a7924bad0b24ce51e976c8cde8e6a8ed3cfdd55ad87064ad38f259
+source_url = https://downloads.arduino.cc/cores/avr-1.8.2.tar.bz2
+source_filename = avr-1.8.2.tar.bz2
+source_hash = 6213d41c6e91a75ac931527da5b10f2dbe0140c8cc1dd41b06cd4e78b943f41b
+patch_filename = arduinocore-avr_1.8.2-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/arduinocore-avr_1.8.2-2/get_patch
+patch_hash = 5e819e2ea0faa8c92484bfd47a2e33831a0dee7b5d3640581a9ac8cf73adc6f8
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/arduinocore-avr_1.8.2-2/avr-1.8.2.tar.bz2
+wrapdb_version = 1.8.2-2


### PR DESCRIPTION
Latest release from WrapDB
https://wrapdb.mesonbuild.com/v2/arduinocore-avr_1.8.2-2/arduinocore-avr.wrap

plus upstream http -> https commit:
https://github.com/mesonbuild/wrapdb/commit/9ca06fc5a4e2e24dd5871bb86d708a1600233cce#diff-21e1434627c91f8f14a77cc9b41ffbd9a8c4425a108c2d0ad85e66868fc9ed05
