### PR TITLE
Fix Micro build errors

### DIFF
--- a/blink.ino
+++ b/blink.ino
@@ -8,10 +8,10 @@
 // Pin 13 has an LED connected on most Arduino boards, except
 // on the Sparkfun Pro Micro where we need to use the RX LED instead.
 // give it a name:
-#ifndef HAVE_PRO_MICRO
-int led = 13;
+#ifdef HAVE_PRO_MICRO
+int led = LED_BUILTIN_RX;
 #else
-int led = 17;
+int led = LED_BUILTIN;
 #endif
 
 // the setup routine runs once when you press reset:

--- a/cross/arduino_micro.txt
+++ b/cross/arduino_micro.txt
@@ -5,7 +5,7 @@ ar = '/usr/bin/avr-gcc-ar'
 strip = '/usr/bin/avr-strip'
 
 [properties]
-variant = 'standard'
+variant = 'micro'
 avrdude_speed = '57600'
 avrdude_programmer = 'avr109'
 requires_reset = true
@@ -26,6 +26,7 @@ cpp_args = [
   '-fno-exceptions',
   '-ffunction-sections',
   '-fdata-sections',
+  '-fno-threadsafe-statics',
   '-mmcu=atmega32u4',
   '-DF_CPU=16000000L',
   '-DUSB_VID=0x2341',

--- a/cross/sparkfun_pro_micro.txt
+++ b/cross/sparkfun_pro_micro.txt
@@ -5,7 +5,7 @@ ar = '/usr/bin/avr-gcc-ar'
 strip = '/usr/bin/avr-strip'
 
 [properties]
-variant = 'standard'
+variant = 'micro'
 avrdude_speed = '57600'
 avrdude_programmer = 'avr109'
 requires_reset = true
@@ -27,6 +27,7 @@ cpp_args = [
   '-fno-exceptions',
   '-ffunction-sections',
   '-fdata-sections',
+  '-fno-threadsafe-statics',
   '-mmcu=atmega32u4',
   '-DF_CPU=16000000L',
   '-DUSB_VID=0x1b4f',


### PR DESCRIPTION
With standard variant multiple errors e.g.
error: ‘RXLED1’ was not declared in this scope

Switching to micro results in
```
cores/arduino/PluggableUSB.cpp:102:(.text+0x53c): undefined reference to
`__cxa_guard_acquire'
cores/arduino/PluggableUSB.cpp:102:(.text+0x55c): undefined reference to
`__cxa_guard_release'
```

---

`-fno-threadsafe-statics` is in platform.txt compiler.cpp.flags:
https://github.com/arduino/ArduinoCore-avr/blob/29d637e0ae724eeaebfd8fcd321903369b8d7b5a/platform.txt#L28

and can then use LED_BUILTIN as we have the right variant selected.

Closes #9
